### PR TITLE
Fix/no eval

### DIFF
--- a/lib/ragamuffins/models/active_record_model_extension.rb
+++ b/lib/ragamuffins/models/active_record_model_extension.rb
@@ -3,17 +3,14 @@ module Ragamuffins
     extend ActiveSupport::Concern
 
     included do
-      # self.send(:include, Ragamuffins::ConfigurationMethods)
 
       # Fetch all the deleted ids from the backend, and return them as an array
-      #   Model.delted_ids = []
-      eval <<-RUBY
-        def self.show_deleted_ids(ids = [])
-          return [] if ids == nil
+      #   Model.deleted_ids = []
+      def self.show_deleted_ids(ids = [])
+        return [] if ids == nil
 
-          ids.collect{|s| s.to_i} - self.where("#{table_name}.id IN (?)", ids).map(&:id)
-        end
-      RUBY
+        ids.collect{|s| s.to_i} - self.where("#{table_name}.id IN (?)", ids).map(&:id)
+      end
     end
   end
 end


### PR DESCRIPTION
@RustComet Do we need the eval? With it, favourite_object tries to use 'favourites' as its table name, ignoring whatever is set.
